### PR TITLE
テスト実行時のDB分離問題を修正

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -90,11 +90,17 @@ python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
 addopts = "--cov=. --cov-report=html --cov-report=term-missing"
+# pytest-env: テスト実行時の環境変数（conftest.pyのインポートより先に設定される）
+env = [
+    "DATABASE_PATH=/tmp/stock_analyzer_test.db",
+    "SESSION_HTTPS_ONLY=false",
+]
 
 [dependency-groups]
 dev = [
     "pytest>=7.0.0",
     "pytest-cov>=4.0.0",
+    "pytest-env>=1.0.0",
     "pandas-stubs>=2.2.2.240807",
     "ruff>=0.13.0",
     "mypy>=1.0.0",

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,29 +1,18 @@
-import os
 from collections.abc import Callable, Generator, Iterator
-from pathlib import Path
 
 import pytest
 import pytest_asyncio
-from pytest import TempPathFactory
 from sqlalchemy.orm import Session
 
 from app.database import models
 from app.database.session import SessionLocal, engine
 
-
-@pytest.fixture(scope="session")
-def test_db_path(tmp_path_factory: TempPathFactory) -> Path:
-    """一時SQLite DBを用意してDATABASE_PATHに差し替え。"""
-    db_dir = tmp_path_factory.mktemp("db")
-    db_path = db_dir / "test.db"
-    os.environ["DATABASE_PATH"] = str(db_path)
-    # テスト環境ではHTTPセッションクッキーを許可
-    os.environ["SESSION_HTTPS_ONLY"] = "false"
-    return db_path
+# 注意: DATABASE_PATH と SESSION_HTTPS_ONLY は pyproject.toml の
+# [tool.pytest.ini_options] env で設定されています（pytest-env）
 
 
 @pytest.fixture(scope="session")
-def db_engine_session(test_db_path: Path) -> Iterator[tuple]:
+def db_engine_session() -> Iterator[tuple]:
     """テスト用エンジン/SessionLocalを初期化し、メタデータを管理。"""
     models.Base.metadata.create_all(bind=engine)
     yield engine, SessionLocal
@@ -53,7 +42,7 @@ def db_session(db_engine_session) -> Generator[Session, None, None]:
 
 
 @pytest.fixture
-def app(test_db_path):
+def app():
     """FastAPIアプリ本体。"""
     from app.api.main import app
 

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -3229,6 +3229,40 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-env"
+version = "1.1.5"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+dependencies = [
+    { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "tomli", marker = "python_full_version < '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/31/27f28431a16b83cab7a636dce59cf397517807d247caa38ee67d65e71ef8/pytest_env-1.1.5.tar.gz", hash = "sha256:91209840aa0e43385073ac464a554ad2947cc2fd663a9debf88d03b01e0cc1cf", size = 8911, upload-time = "2024-09-17T22:39:18.566Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/b8/87cfb16045c9d4092cfcf526135d73b88101aac83bc1adcf82dfb5fd3833/pytest_env-1.1.5-py3-none-any.whl", hash = "sha256:ce90cf8772878515c24b31cd97c7fa1f4481cd68d588419fd45f10ecaee6bc30", size = 6141, upload-time = "2024-09-17T22:39:16.942Z" },
+]
+
+[[package]]
+name = "pytest-env"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12'",
+    "python_full_version == '3.11.*'",
+    "python_full_version == '3.10.*'",
+]
+dependencies = [
+    { name = "pytest", version = "9.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "tomli", marker = "python_full_version == '3.10.*'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/13/12/9c87d0ca45d5992473208bcef2828169fa7d39b8d7fc6e3401f5c08b8bf7/pytest_env-1.2.0.tar.gz", hash = "sha256:475e2ebe8626cee01f491f304a74b12137742397d6c784ea4bc258f069232b80", size = 8973, upload-time = "2025-10-09T19:15:47.42Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/98/822b924a4a3eb58aacba84444c7439fce32680592f394de26af9c76e2569/pytest_env-1.2.0-py3-none-any.whl", hash = "sha256:d7e5b7198f9b83c795377c09feefa45d56083834e60d04767efd64819fc9da00", size = 6251, upload-time = "2025-10-09T19:15:46.077Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -3881,6 +3915,8 @@ dev = [
     { name = "pytest-asyncio", version = "1.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "pytest-asyncio", version = "1.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "pytest-cov" },
+    { name = "pytest-env", version = "1.1.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pytest-env", version = "1.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "ruff" },
     { name = "types-click-log" },
 ]
@@ -3922,6 +3958,7 @@ dev = [
     { name = "pytest", specifier = ">=7.0.0" },
     { name = "pytest-asyncio", specifier = ">=0.23.6" },
     { name = "pytest-cov", specifier = ">=4.0.0" },
+    { name = "pytest-env", specifier = ">=1.0.0" },
     { name = "ruff", specifier = ">=0.13.0" },
     { name = "types-click-log", specifier = ">=0.4.0.20250413" },
 ]


### PR DESCRIPTION
## Summary
- pytest実行時に本番DBが破壊される問題を修正
- pytest-envを導入し、conftest.pyのインポートより先に環境変数が設定されるよう変更
- conftest.pyから不要な環境変数設定コードを削除してシンプル化

## 背景
テスト実行時に `conftest.py` で環境変数を設定していましたが、`from app.database.session import engine` のインポート時点で既にengineが本番DBパスで作成されてしまっていました。これにより、テスト実行のたびに本番DBの全テーブルが削除される問題が発生していました。

## 解決策
`pytest-env` プラグインを使用し、`pyproject.toml` で環境変数を設定することで、conftest.pyのインポートより先に環境変数が適用されるようにしました。

## Test plan
- [x] 全44テストがパス
- [x] mypy型チェックがパス
- [x] ruff lintチェックがパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)