### PR TITLE
スマホ表示時のログイン画面上部の空きスペースを削減

### DIFF
--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -57,8 +57,8 @@ const Login = () => {
   }
 
   return (
-    <div className="flex items-center justify-center min-h-screen bg-gray-900">
-      <div className="w-full max-w-md p-8 bg-gray-800 rounded-lg shadow-xl">
+    <div className="flex items-start md:items-center justify-center min-h-screen bg-gray-900 pt-16 md:pt-0">
+      <div className="w-full max-w-md p-8 mx-4 bg-gray-800 rounded-lg shadow-xl">
         <h1 className="text-2xl font-bold text-white text-center mb-8">
           株式分析システム
         </h1>


### PR DESCRIPTION
## 概要
Issue #13 に対応。スマホからログイン画面にアクセスしたとき、上部の空きスペースが多すぎる問題を修正しました。

## 変更内容
- **モバイル表示**: 上部から配置（`items-start`）し、適度なパディング（`pt-16` = 64px）を確保
- **デスクトップ表示**: 従来通り中央配置（`md:items-center md:pt-0`）を維持
- **フォームコンテナ**: 左右に余白（`mx-4`）を追加してモバイルでの視認性を向上

## 変更ファイル
- `frontend/src/pages/Login.tsx` (2行変更)

## テスト計画
- [ ] スマホでログイン画面にアクセスし、上部の空きスペースが適切に削減されていることを確認
- [ ] デスクトップでログイン画面にアクセスし、中央配置が維持されていることを確認
- [ ] タブレット（中間サイズ）でのレイアウトも確認
- [ ] フォームの入力と送信が正常に動作することを確認

Closes #13