### PR TITLE
feat: ダッシュボード改善 - 実用的な情報への再構成とカード遷移機能追加

### DIFF
--- a/backend/app/api/routers/candidates.py
+++ b/backend/app/api/routers/candidates.py
@@ -61,9 +61,12 @@ async def get_investment_candidates(
             market_filter=filter_value,
         )
 
-        # スコアフィルタを適用
+        # スコアフィルタを適用（analysis_scoreがNoneの銘柄は除外）
         if min_score is not None:
-            candidates = [c for c in candidates if c.get("analysis_score", 0) >= min_score]
+            candidates = [
+                c for c in candidates
+                if c.get("analysis_score") is not None and c["analysis_score"] >= min_score
+            ]
 
         # レスポンス形式に変換（NaN値を除外）
         result = []

--- a/frontend/src/pages/Candidates.tsx
+++ b/frontend/src/pages/Candidates.tsx
@@ -53,7 +53,7 @@ const Candidates = () => {
     if (param === null) return defaultValue
     if (typeof defaultValue === 'number') {
       const parsed = parseFloat(param)
-      return isNaN(parsed) ? defaultValue : parsed
+      return Number.isNaN(parsed) ? defaultValue : parsed
     }
     return param
   }

--- a/frontend/src/pages/Candidates.tsx
+++ b/frontend/src/pages/Candidates.tsx
@@ -294,13 +294,15 @@ const Candidates = () => {
     setLoading(true)
     setError(null)
     try {
+      // フロントエンドとバックエンドのデフォルト値が異なるため、常にパラメータを送信
+      // （例: フロントエンドのminDividendデフォルトは3.0、バックエンドは0.0）
       const params = new URLSearchParams({
         limit: '50',
         max_divergence: maxDivergence.toString(),
         min_dividend: minDividend.toString(),
         market_filter: marketFilter,
       })
-      // minScoreが0より大きい場合のみパラメータに追加
+      // minScoreは0の場合「フィルタなし」と同義のため省略可能
       if (minScore > 0) {
         params.append('min_score', minScore.toString())
       }

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,19 +1,27 @@
 import {
   AimOutlined,
   CalendarOutlined,
+  DollarOutlined,
   LineChartOutlined,
-  SearchOutlined,
-  ShopOutlined,
+  RiseOutlined,
   StarOutlined,
+  StockOutlined,
 } from '@ant-design/icons'
 import { useQuery } from '@tanstack/react-query'
-import { Button, Card, Col, Row, Spin, Statistic } from 'antd'
-import { Link } from 'react-router-dom'
-import { analysisApi, candidatesApi } from '../services/api'
+import { Button, Card, Col, Row, Spin, Statistic, Typography } from 'antd'
+import { Link, useNavigate } from 'react-router-dom'
+import { useAuth } from '../contexts/AuthContext'
+import { analysisApi, candidatesApi, portfolioApi } from '../services/api'
+import type { DashboardPortfolioSummary } from '../types/portfolio'
 import type { CandidatesCount, SystemStats } from '../types/stock'
 
+const { Title } = Typography
+
 const Dashboard = () => {
-  // システム統計取得
+  const navigate = useNavigate()
+  const { user } = useAuth()
+
+  // システム統計取得（プライム市場）
   const { data: systemStats, isLoading: statsLoading } = useQuery<SystemStats>({
     queryKey: ['systemStats'],
     queryFn: analysisApi.getSystemStats,
@@ -26,7 +34,15 @@ const Dashboard = () => {
       queryFn: candidatesApi.getCandidatesCount,
     })
 
-  if (statsLoading || candidatesLoading) {
+  // ポートフォリオ概要取得（ログイン時のみ）
+  const { data: portfolioSummary, isLoading: portfolioLoading } =
+    useQuery<DashboardPortfolioSummary>({
+      queryKey: ['portfolioSummary'],
+      queryFn: portfolioApi.getPortfolioSummary,
+      enabled: !!user,
+    })
+
+  if (statsLoading || candidatesLoading || (user && portfolioLoading)) {
     return (
       <div style={{ padding: 24, textAlign: 'center' }}>
         <Spin size="large" />
@@ -34,67 +50,76 @@ const Dashboard = () => {
     )
   }
 
+  // 投資候補カードクリック時のハンドラ
+  const handleCandidatesClick = () => {
+    navigate('/candidates?market=prime&minDividend=3&maxDivergence=-5')
+  }
+
+  // 高スコアカードクリック時のハンドラ
+  const handleHighScoreClick = () => {
+    navigate('/candidates?market=prime&minScore=5')
+  }
+
   return (
     <div style={{ padding: 24 }}>
-      <h1 style={{ marginBottom: 24 }}>📊 ダッシュボード</h1>
+      <Title level={2} style={{ marginBottom: 24 }}>
+        ダッシュボード
+      </Title>
 
+      {/* 投資候補情報セクション */}
+      <Title level={4} style={{ marginBottom: 16 }}>
+        投資候補情報（プライム市場）
+      </Title>
       <Row gutter={[16, 16]} style={{ marginBottom: 32 }}>
-        <Col xs={24} sm={12} lg={8}>
-          <Card>
-            <Statistic
-              title="企業データ"
-              value={systemStats?.companies_count || 0}
-              prefix={<ShopOutlined />}
-              suffix="社"
-            />
-          </Card>
-        </Col>
-        <Col xs={24} sm={12} lg={8}>
-          <Card>
-            <Statistic
-              title="株価データ有り"
-              value={systemStats?.symbols_with_prices || 0}
-              prefix={<LineChartOutlined />}
-              suffix="銘柄"
-            />
-          </Card>
-        </Col>
-        <Col xs={24} sm={12} lg={8}>
-          <Card>
-            <Statistic
-              title="分析済み銘柄"
-              value={systemStats?.symbols_with_technical || 0}
-              prefix={<SearchOutlined />}
-              suffix="銘柄"
-            />
-          </Card>
-        </Col>
-        <Col xs={24} sm={12} lg={8}>
-          <Card>
+        <Col xs={24} sm={12} lg={6}>
+          <Card
+            hoverable
+            onClick={handleCandidatesClick}
+            style={{ cursor: 'pointer' }}
+          >
             <Statistic
               title="投資候補"
               value={candidatesCount?.total_candidates || 0}
               prefix={<AimOutlined />}
-              suffix="銘柄"
+              suffix={
+                <span>
+                  銘柄 <RiseOutlined style={{ fontSize: 12 }} />
+                </span>
+              }
               valueStyle={{ color: '#3f8600' }}
             />
           </Card>
         </Col>
-        <Col xs={24} sm={12} lg={8}>
-          <Card>
+        <Col xs={24} sm={12} lg={6}>
+          <Card
+            hoverable
+            onClick={handleHighScoreClick}
+            style={{ cursor: 'pointer' }}
+          >
             <Statistic
               title="高スコア候補"
               value={candidatesCount?.high_score || 0}
               prefix={<StarOutlined />}
-              suffix="銘柄"
+              suffix={
+                <span>
+                  銘柄 <RiseOutlined style={{ fontSize: 12 }} />
+                </span>
+              }
               valueStyle={{ color: '#cf1322' }}
             />
           </Card>
         </Col>
-        <Col xs={24} sm={12} lg={8}>
+      </Row>
+
+      {/* データ更新状況セクション */}
+      <Title level={4} style={{ marginBottom: 16 }}>
+        データ更新状況
+      </Title>
+      <Row gutter={[16, 16]} style={{ marginBottom: 32 }}>
+        <Col xs={24} sm={12} lg={6}>
           <Card>
             <Statistic
-              title="最新更新日"
+              title="最終更新日"
               value={
                 systemStats?.latest_price_date
                   ? new Date(systemStats.latest_price_date).toLocaleDateString(
@@ -106,14 +131,103 @@ const Dashboard = () => {
             />
           </Card>
         </Col>
+        <Col xs={24} sm={12} lg={6}>
+          <Card>
+            <Statistic
+              title="株価データ"
+              value={systemStats?.symbols_with_prices || 0}
+              prefix={<LineChartOutlined />}
+              suffix="銘柄"
+            />
+          </Card>
+        </Col>
       </Row>
 
-      <h2 style={{ marginBottom: 16 }}>🚀 クイックアクション</h2>
+      {/* ポートフォリオ概要セクション（ログイン時のみ表示） */}
+      {user && (
+        <>
+          <Title level={4} style={{ marginBottom: 16 }}>
+            ポートフォリオ概要
+          </Title>
+          <Row gutter={[16, 16]} style={{ marginBottom: 32 }}>
+            {portfolioSummary?.has_portfolio ? (
+              <>
+                <Col xs={24} sm={8} lg={6}>
+                  <Card>
+                    <Statistic
+                      title="保有銘柄数"
+                      value={portfolioSummary.positions_count}
+                      prefix={<StockOutlined />}
+                      suffix="銘柄"
+                    />
+                  </Card>
+                </Col>
+                <Col xs={24} sm={8} lg={6}>
+                  <Card>
+                    <Statistic
+                      title="総損益"
+                      value={portfolioSummary.total_profit_loss}
+                      prefix={<DollarOutlined />}
+                      suffix="円"
+                      precision={0}
+                      valueStyle={{
+                        color:
+                          portfolioSummary.total_profit_loss >= 0
+                            ? '#3f8600'
+                            : '#cf1322',
+                      }}
+                      formatter={(value) =>
+                        `${Number(value) >= 0 ? '+' : ''}${Number(value).toLocaleString()}`
+                      }
+                    />
+                  </Card>
+                </Col>
+                <Col xs={24} sm={8} lg={6}>
+                  <Card>
+                    <Statistic
+                      title="損益率"
+                      value={portfolioSummary.total_profit_loss_rate}
+                      prefix={<RiseOutlined />}
+                      suffix="%"
+                      precision={2}
+                      valueStyle={{
+                        color:
+                          portfolioSummary.total_profit_loss_rate >= 0
+                            ? '#3f8600'
+                            : '#cf1322',
+                      }}
+                      formatter={(value) =>
+                        `${Number(value) >= 0 ? '+' : ''}${Number(value).toFixed(2)}`
+                      }
+                    />
+                  </Card>
+                </Col>
+              </>
+            ) : (
+              <Col xs={24} sm={12} lg={8}>
+                <Card>
+                  <p style={{ marginBottom: 16, color: '#8c8c8c' }}>
+                    ポートフォリオがまだありません
+                  </p>
+                  <Link to="/portfolio">
+                    <Button type="primary">ポートフォリオを作成</Button>
+                  </Link>
+                </Card>
+              </Col>
+            )}
+          </Row>
+        </>
+      )}
+
+      {/* クイックアクション */}
+      <Title level={4} style={{ marginBottom: 16 }}>
+        クイックアクション
+      </Title>
       <Row gutter={[16, 16]}>
         <Col xs={24} sm={12} lg={8}>
           <Card hoverable>
             <Card.Meta
-              title="🎯 投資候補を見る"
+              title="投資候補を見る"
               description="AI分析による投資候補銘柄をチェック"
             />
             <Link to="/candidates">
@@ -126,7 +240,7 @@ const Dashboard = () => {
         <Col xs={24} sm={12} lg={8}>
           <Card hoverable>
             <Card.Meta
-              title="📊 銘柄検索"
+              title="銘柄検索"
               description="個別銘柄の詳細情報を確認"
             />
             <Link to="/stocks">
@@ -139,7 +253,7 @@ const Dashboard = () => {
         <Col xs={24} sm={12} lg={8}>
           <Card hoverable>
             <Card.Meta
-              title="📈 市場分析"
+              title="市場分析"
               description="技術分析とトレンドを分析"
             />
             <Link to="/analysis">

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -75,7 +75,7 @@ const Dashboard = () => {
           <Card
             hoverable
             onClick={handleCandidatesClick}
-            style={{ cursor: 'pointer' }}
+            style={{ cursor: 'pointer', borderColor: '#1890ff' }}
           >
             <Statistic
               title="投資候補"
@@ -94,7 +94,7 @@ const Dashboard = () => {
           <Card
             hoverable
             onClick={handleHighScoreClick}
-            style={{ cursor: 'pointer' }}
+            style={{ cursor: 'pointer', borderColor: '#1890ff' }}
           >
             <Statistic
               title="高スコア候補"

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -10,6 +10,7 @@ import type {
 import { ApiException } from '../types/error'
 import type {
   BuyRequest,
+  DashboardPortfolioSummary,
   DepositRequest,
   PortfolioCreateRequest,
   PortfolioDetail,
@@ -203,6 +204,12 @@ export const adminApi = {
 
 // ポートフォリオAPI
 export const portfolioApi = {
+  // ダッシュボード用ポートフォリオ概要取得
+  getPortfolioSummary: async (): Promise<DashboardPortfolioSummary> => {
+    const response = await api.get('/portfolios/summary')
+    return response.data
+  },
+
   // ポートフォリオ一覧取得
   getPortfolios: async (): Promise<PortfolioSummary[]> => {
     const response = await api.get('/portfolios/')

--- a/frontend/src/types/portfolio.ts
+++ b/frontend/src/types/portfolio.ts
@@ -98,3 +98,10 @@ export interface TransactionResponse {
   created_at: string
   notes: string | null
 }
+
+export interface DashboardPortfolioSummary {
+  has_portfolio: boolean
+  positions_count: number
+  total_profit_loss: number
+  total_profit_loss_rate: number
+}

--- a/frontend/src/types/stock.ts
+++ b/frontend/src/types/stock.ts
@@ -47,11 +47,9 @@ export interface TechnicalAnalysis {
 }
 
 export interface SystemStats {
-  companies_count: number
   symbols_with_prices: number
-  symbols_with_technical: number
   latest_price_date?: string
-  latest_analysis_date?: string
+  market_filter?: string
 }
 
 export interface CandidatesCount {


### PR DESCRIPTION
## Summary
- ダッシュボードを3セクション構成に再編成
  - 投資候補情報（プライム市場）: 投資候補数、高スコア候補数
  - データ更新状況: 最終更新日、株価データ数
  - ポートフォリオ概要（ログイン時のみ）: 保有銘柄数、総損益、損益率
- 不要な統計（全企業数、分析済み銘柄）を削除
- カードクリックでCandidatesページへ遷移する機能を追加
- 投資候補APIに市場フィルタ、スコアフィルタを追加
- 投資候補ページにURLパラメータ対応とスコアカラムを追加
- ポートフォリオサマリーAPIを新規追加

## 変更ファイル
### Backend
- `database_manager.py`: 市場フィルタ対応のデータベース統計取得
- `analysis.py`: SystemStats簡素化、市場フィルタ対応
- `candidates.py`: スコアフィルタ追加、カウントAPI修正
- `portfolios.py`: サマリーAPI追加

### Frontend
- `Dashboard.tsx`: 3セクション構成に再構成、カード遷移機能
- `Candidates.tsx`: URLパラメータ対応、スコアフィルタ・カラム追加
- `api.ts`, `stock.ts`, `portfolio.ts`: 型定義・API関数更新

## Test plan
- [ ] ダッシュボードが3セクションで正しく表示される
- [ ] 投資候補カードクリック → `/candidates?market=prime&minDividend=3&maxDivergence=-5` へ遷移
- [ ] 高スコアカードクリック → `/candidates?market=prime&minScore=5` へ遷移
- [ ] 株価データ数、最終更新日が正しく表示される（プライム市場のみ）
- [ ] ポートフォリオ概要がログイン時に表示される
- [ ] Candidatesページでスコアスライダーが動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)